### PR TITLE
取置解放、_取置完了の外部キー制約から所蔵品番号を除去

### DIFF
--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -122,7 +122,7 @@ CREATE TABLE 取置._準備完了
   取置番号 INTEGER PRIMARY KEY REFERENCES 取置.取置,
   所蔵品番号 VARCHAR(40) NOT NULL,
   UNIQUE(所蔵品番号),
-  FOREIGN KEY (取置番号, 所蔵品番号) REFERENCES 取置.取置 (取置番号, 所蔵品番号),
+  FOREIGN KEY (取置番号) REFERENCES 取置.取置 (取置番号),
   登録日時 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
 );
 
@@ -132,7 +132,7 @@ CREATE TABLE 取置.取置解放
   取置番号 INTEGER PRIMARY KEY REFERENCES 取置.取置,
   所蔵品番号 VARCHAR(40) NOT NULL,
   登録日時 TIMESTAMP   NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  FOREIGN KEY (取置番号, 所蔵品番号) REFERENCES 取置.取置 (取置番号, 所蔵品番号)
+  FOREIGN KEY (取置番号) REFERENCES 取置.取置 (取置番号)
 );
 -- 取置の期限切れ
 CREATE TABLE 取置.取置期限切れ


### PR DESCRIPTION
postgresql で動かしたところ、取置._準備完了の外部キー制約でエラーが出ました.
所蔵品番号を外部キー制約から除外しています.

```
Failed to execute SQL script statement #28 of URL resources/main/schema.sql]: CREATE TABLE 取置._準備完了 ( 取置番号 INTEGER PRIMARY KEY REFERENCES 取置.取置, 所蔵品番号 VARCHAR(40) NOT NULL, UNIQUE(所蔵品番号), FOREIGN KEY (取置番号, 所蔵品番号) REFERENCES 取置.取置 (取置番号, 所蔵品番号), 登録日時 TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ); nested exception is org.postgresql.util.PSQLException: ERROR: there is no unique constraint matching given keys for referenced table "取置"
```
