### PR TITLE
GradleをJDK17に対応したものへバージョン アップ

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
JDK17に正式に対応したGradleのバージョンがリリースされたようですので、バージョンアップしてはいかがでしょうか。
<https://docs.gradle.org/current/release-notes.html>
<https://docs.gradle.org/current/userguide/compatibility.html>